### PR TITLE
スキルセットのテーブルの列の幅を均一化

### DIFF
--- a/components/Skill.vue
+++ b/components/Skill.vue
@@ -125,6 +125,8 @@
     width: 100%;
     margin-top: 20px;
     margin-bottom: 40px;
+    table-layout: fixed;
+    word-wrap: break-word;
   }
 
 </style>


### PR DESCRIPTION
to fix#49

##  仕様
- スキルセットのテーブルの列の幅を均一化
- 文字の折り返しは自動的に行う

## 動作確認
- [x] 適当にローカルで小さい幅と大きい幅で均一に・折り返しできている