### PR TITLE
travisでyarnを使うように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
   - master
 
 install:
-- npm install
-- npm run generate
+- yarn
+- yarn build
 
 script:
 - echo "Skipping tests"


### PR DESCRIPTION
## why
- travisのビルドが落ちるようになった
  - package.jsonを削除したため
  - yarnを代わりに使いたい

## what
- yarnでビルドするようにtravis.ymlを修正