### PR TITLE
Fix header settings

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -17,17 +17,17 @@
           <img v-if="!isHalloweenStyle" src="~/assets/images/common/top.png" sizes="(min-width:80px) 50vw, 100vw" width="41" srcset="~/assets/images/common/top.png 200w, ~/assets/images/common/top.png 400w">
           <img v-else src="~/assets/images/common/top-halloween.png" sizes="(min-width:80px) 50vw, 100vw" width="41" srcset="~/assets/images/common/top-halloween.png 200w, ~/assets/images/common/top-halloween.png 400w">
         </div>
-        <div id="menu02" class="menu" @click="onClickMenuButton">
+        <div id="menu02" class="menu" v-scroll-to="'#skill'" @click="onClickMenuButton">
           <nuxt-link to="./skill">
             <img v-if="!isHalloweenStyle" src="~/assets/images/common/skill.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/skill.png 200w, ~/assets/images/common/skill.png 400w">
             <img v-else src="~/assets/images/common/skill-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/skill-halloween.png 200w, ~/assets/images/common/skill-halloween.png 400w">
           </nuxt-link>
         </div>
-        <div id="menu04" class="menu" v-scroll-to="'#profile'" @click="onClickMenuButton">
+        <div id="menu03" class="menu" v-scroll-to="'#profile'" @click="onClickMenuButton">
           <img v-if="!isHalloweenStyle" src="~/assets/images/common/story.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/story.png 200w, ~/assets/images/common/story.png 400w">
           <img v-else src="~/assets/images/common/story-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/story-halloween.png 200w, ~/assets/images/common/story-halloween.png 400w">
         </div>
-        <div id="menu05" class="menu" v-scroll-to="'#keyword'" @click="onClickMenuButton">
+        <div id="menu04" class="menu" v-scroll-to="'#keyword'" @click="onClickMenuButton">
           <img v-if="!isHalloweenStyle" src="~/assets/images/common/keyword.png" sizes="(min-width:180px) 50vw, 100vw" width="92" srcset="~/assets/images/common/keyword.png 200w, ~/assets/images/common/keyword.png 400w">
           <img v-else src="~/assets/images/common/keyword-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="92" srcset="~/assets/images/common/keyword-halloween.png 200w, ~/assets/images/common/keyword-halloween.png 400w">
         </div>

--- a/components/NotIndexPageHeader.vue
+++ b/components/NotIndexPageHeader.vue
@@ -7,41 +7,15 @@
           <img v-else src="~/assets/images/common/logo-halloween.png" sizes="(min-width:80px) 50vw, 100vw" width="150" srcset="~/assets/images/common/logo-halloween.png 200w, ~/assets/images/common/logo-halloween.png 400w">
         </nuxt-link>
       </div>
-      <div id="button-menu">
-        <nuxt-link to="./#top">
-          <img v-if="!isMenuOpen" src="~/assets/images/icons/menu.svg" sizes="(min-width:100px) 50vw, 100vw" width="42" srcset="~/assets/images/icons/menu.svg 200w, ~/assets/images/icons/menu.svg 400w">
-          <img v-else src="~/assets/images/icons/close.svg" sizes="(min-width:100px) 50vw, 100vw" width="42" srcset="~/assets/images/icons/close.svg 200w, ~/assets/images/icons/close.svg 400w">
-        </nuxt-link>
+      <div id="button-menu" @click="onClickMenuButton">
+        <img v-if="!isMenuOpen" src="~/assets/images/icons/menu.svg" sizes="(min-width:100px) 50vw, 100vw" width="42" srcset="~/assets/images/icons/menu.svg 200w, ~/assets/images/icons/menu.svg 400w">
+        <img v-else src="~/assets/images/icons/close.svg" sizes="(min-width:100px) 50vw, 100vw" width="42" srcset="~/assets/images/icons/close.svg 200w, ~/assets/images/icons/close.svg 400w">
       </div>
       <nav id="menu">
         <div id="menu01" class="menu">
           <nuxt-link to="./#top">
             <img v-if="!isHalloweenStyle" src="~/assets/images/common/top.png" sizes="(min-width:80px) 50vw, 100vw" width="41" srcset="~/assets/images/common/top.png 200w, ~/assets/images/common/top.png 400w">
             <img v-else src="~/assets/images/common/top-halloween.png" sizes="(min-width:80px) 50vw, 100vw" width="41" srcset="~/assets/images/common/top-halloween.png 200w, ~/assets/images/common/top-halloween.png 400w">
-          </nuxt-link>
-        </div>
-        <div id="menu05" class="menu">
-          <nuxt-link to="./skill">
-            <img v-if="!isHalloweenStyle" src="~/assets/images/common/skill.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/skill.png 200w, ~/assets/images/common/skill.png 400w">
-            <img v-else src="~/assets/images/common/skill-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/skill-halloween.png 200w, ~/assets/images/common/skill-halloween.png 400w">
-          </nuxt-link>
-        </div>
-        <div id="menu02" class="menu">
-          <nuxt-link to="./#news">
-            <img v-if="!isHalloweenStyle" src="~/assets/images/common/news.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/news.png 200w, ~/assets/images/common/news.png 400w">
-            <img v-else src="~/assets/images/common/news-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/news-halloween.png 200w, ~/assets/images/common/news-halloween.png 400w">
-          </nuxt-link>
-        </div>
-        <div id="menu03" class="menu">
-          <nuxt-link to="./#story">
-            <img v-if="!isHalloweenStyle" src="~/assets/images/common/story.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/story.png 200w, ~/assets/images/common/story.png 400w">
-            <img v-else src="~/assets/images/common/story-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="58" srcset="~/assets/images/common/story-halloween.png 200w, ~/assets/images/common/story-halloween.png 400w">
-          </nuxt-link>
-        </div>
-        <div id="menu04" class="menu">
-          <nuxt-link to="./#keyword">
-            <img v-if="!isHalloweenStyle" src="~/assets/images/common/keyword.png" sizes="(min-width:180px) 50vw, 100vw" width="92" srcset="~/assets/images/common/keyword.png 200w, ~/assets/images/common/keyword.png 400w">
-            <img v-else src="~/assets/images/common/keyword-halloween.png" sizes="(min-width:180px) 50vw, 100vw" width="92" srcset="~/assets/images/common/keyword-halloween.png 200w, ~/assets/images/common/keyword-halloween.png 400w">
           </nuxt-link>
         </div>
       </nav>


### PR DESCRIPTION
## why
- トップページのヘッダのskillが機能していなかった
- スキルページのヘッダが機能していなかった


## what
- トップページのヘッダのskillを押すとスキルページに移動するよう設定
- スキルページのヘッダをtopだけに整理し、topを押すとトップページに遷移するように設定