### PR TITLE
プロフィールのテキスト更新＆レイアウトを変更してみやすくする

### DIFF
--- a/components/Profile.vue
+++ b/components/Profile.vue
@@ -12,14 +12,18 @@
         </p>
         <p>
           北海道大学情報科学研究科の修士２年生。
-          <a href="https://kitagoe.jp/news/aitokyolab-hokkaido-start/">AI HOKKAIDO LAB</a>と
-          <a href="https://satudora.jp/">サツドラ</a>で
+          <a href="https://kitagoe.jp/news/aitokyolab-hokkaido-start/"
+            >AI HOKKAIDO LAB</a
+          >と <a href="https://satudora.jp/">サツドラ</a>で
           エンジニアバイト（React, Flutter, Firebase）として計２年間勤務。
         </p>
         <p>
-          個人で<a href="https://itunes.apple.com/jp/app/id1218804893?mt=8">「フレーズ英単語」</a>(iOS/Swift)、
-          チームで<a href="https://hufurima.com/">「ホクマ」</a>（Web/Django)、
-          <a href="https://twitter.com/MatchingStudy">「スタマチ」</a>(iOS/Android/Flutter/Django)を開発・運営しています。
+          個人で<a href="https://itunes.apple.com/jp/app/id1218804893?mt=8"
+            >「フレーズ英単語」</a
+          >(iOS/Swift)、 チームで<a href="https://hufurima.com/">「ホクマ」</a
+          >（Web/Django)、
+          <a href="https://twitter.com/MatchingStudy">「スタマチ」</a
+          >(iOS/Android/Flutter/Django)を開発・運営しています。
         </p>
       </div>
     </div>
@@ -27,98 +31,96 @@
 </template>
 
 <script>
-  export default {
-    components: {
-    },
-    computed: {
-      isHalloweenStyle () { return this.$store.state.isHalloweenStyle }
-    },
-    name: "Profile"
-  }
+export default {
+  components: {},
+  computed: {
+    isHalloweenStyle() {
+      return this.$store.state.isHalloweenStyle;
+    }
+  },
+  name: "Profile"
+};
 </script>
 
 <style scoped>
+.title-wrap {
+  text-align: center;
+}
 
-  .title-wrap{
-    text-align: center;
-  }
+#profile-wrap .profile {
+  width: 80%;
+  margin: 0 auto;
+}
 
-  #profile-wrap .profile {
-    width: 80%;
-    margin: 0 auto;
-  }
+#profile-wrap .profile {
+  margin-top: 40px;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 800;
+}
 
-  #profile-wrap .profile {
-    margin-top: 40px;
-    font-size: 20px;
-    line-height: 28px;
-    font-weight: 800;
-  }
+#wrap.sideA #profile-wrap .profile {
+  color: #767b85;
+}
 
-  #wrap.sideA #profile-wrap .profile{
-    color: #767b85;
-  }
+#wrap.sideB #profile-wrap .profile {
+  color: #363b55;
+}
 
-  #wrap.sideB #profile-wrap .profile{
-    color: #363b55;
-  }
+.title-wrap h3 {
+  width: 224px;
+  font-family: Arvo;
+  font-weight: 700;
+  font-size: 25px;
+  line-height: 1.8;
+  letter-spacing: 7px;
+  text-align: center;
+  padding-left: 7px;
+  margin: 0 auto 80px;
+  border-bottom: 4px solid #0082f2;
+}
 
-  .title-wrap h3 {
-    width: 224px;
-    font-family: Arvo;
-    font-weight: 700;
-    font-size: 25px;
-    line-height: 1.8;
-    letter-spacing: 7px;
-    text-align: center;
-    padding-left: 7px;
-    margin: 0 auto 80px;
-    border-bottom: 4px solid #0082f2;
-  }
+.title-wrap p {
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 6px;
+  text-align: center;
+  padding-left: 6px;
+}
 
-  .title-wrap p {
-    font-weight: 500;
-    font-size: 12px;
-    line-height: 1;
-    letter-spacing: 6px;
-    text-align: center;
-    padding-left: 6px;
-  }
+.title-wrap h3 {
+  width: 180px;
+  font-size: 21px;
+  letter-spacing: 6px;
+  padding-left: 6px;
+  margin: 0 auto 56px;
+}
 
-  .title-wrap h3 {
-    width: 180px;
-    font-size: 21px;
-    letter-spacing: 6px;
-    padding-left: 6px;
-    margin: 0 auto 56px;
-  }
+.title-wrap p {
+  font-size: 10px;
+  padding-left: 6px;
+}
 
-  .title-wrap p {
-    font-size: 10px;
-    padding-left: 6px;
-  }
+#wrap.sideA .title-wrap h3 {
+  color: #50aa32 !important;
+  border-bottom: 4px solid #50aa32;
+}
 
-  #wrap.sideA .title-wrap h3 {
-    color: #50aa32!important;
-    border-bottom: 4px solid #50aa32;
-  }
+#wrap.sideA .title-wrap p {
+  color: #50aa32 !important;
+}
 
-  #wrap.sideA .title-wrap p {
-    color: #50aa32!important;
-  }
+#wrap.sideB .title-wrap p {
+  color: black !important;
+}
 
-  #wrap.sideB .title-wrap p {
-    color: black!important;
-  }
+#wrap.sideB .title-wrap h3 {
+  color: black !important;
+  border-bottom: 4px solid #ffe800;
+}
 
-  #wrap.sideB .title-wrap h3 {
-    color: black!important;
-    border-bottom: 4px solid #ffe800;
-  }
-
-
-  .title-wrap {
-    margin-top: 14px;
-  }
-
+.title-wrap {
+  margin-top: 14px;
+}
 </style>

--- a/components/Profile.vue
+++ b/components/Profile.vue
@@ -49,6 +49,12 @@ export default {
   margin: 0 auto;
 }
 
+@media screen and (min-width: 900px) {
+  #profile-wrap .profile {
+    width: 60%;
+  }
+}
+
 #profile-wrap .profile {
   margin-top: 40px;
   font-size: 18px;

--- a/components/Profile.vue
+++ b/components/Profile.vue
@@ -8,22 +8,19 @@
     <div id="profile-wrap">
       <div class="profile">
         <p>
-          2020年4月25日版
-        </p>
-        <p>
           北海道大学情報科学研究科の修士２年生。
-          <a href="https://kitagoe.jp/news/aitokyolab-hokkaido-start/"
-            >AI HOKKAIDO LAB</a
-          >と <a href="https://satudora.jp/">サツドラ</a>で
-          エンジニアバイト（React, Flutter, Firebase）として計２年間勤務。
-        </p>
-        <p>
-          個人で<a href="https://itunes.apple.com/jp/app/id1218804893?mt=8"
+          <a href="https://satudora.jp/">サツドラ</a>で エンジニアバイト（React,
+          Flutter, Firebase）として計２年間勤務。 個人で<a
+            href="https://itunes.apple.com/jp/app/id1218804893?mt=8"
             >「フレーズ英単語」</a
           >(iOS/Swift)、 チームで<a href="https://hufurima.com/">「ホクマ」</a
           >（Web/Django)、
           <a href="https://twitter.com/MatchingStudy">「スタマチ」</a
           >(iOS/Android/Flutter/Django)を開発・運営しています。
+        </p>
+        <br />
+        <p style="text-align: right">
+          2020年7月18日版
         </p>
       </div>
     </div>

--- a/components/Profile.vue
+++ b/components/Profile.vue
@@ -54,9 +54,15 @@ export default {
 
 #profile-wrap .profile {
   margin-top: 40px;
-  font-size: 20px;
+  font-size: 18px;
   line-height: 28px;
   font-weight: 800;
+}
+
+@media screen and (max-width: 900px) {
+  #profile-wrap .profile {
+    font-size: 16px;
+  }
 }
 
 #wrap.sideA #profile-wrap .profile {


### PR DESCRIPTION
## why
Fix #77 

## what
- プロフィールのテキストを最新版に更新（情報の修正）
- PC(横900px以上)で余白を20% -> 40%に拡大してみやすくした
- スマホ(横900px以下)でフォントを小さくしてみやすくした


<img width=300 src="https://user-images.githubusercontent.com/24940519/87848101-fe885600-c917-11ea-8692-5e7a56f98718.png">
